### PR TITLE
Fix open_on_start component ignoring modifier and size parameters

### DIFF
--- a/lua/officer/ui.lua
+++ b/lua/officer/ui.lua
@@ -15,14 +15,14 @@ function M.resize_windows_on_stack()
 end
 
 ---@param bufnr number
-function M.add_window_to_stack(bufnr)
+function M.add_window_to_stack(bufnr, modifier, size)
   local last_window = stack[#stack]
   if not last_window or not vim.api.nvim_win_is_valid(last_window.winid) then
-    M.create_window(bufnr, "botright vertical", get_size())
+    M.create_window(bufnr, modifier, size)
     return
   end
   vim.api.nvim_set_current_win(last_window.winid)
-  M.create_window(bufnr, "belowright")
+  M.create_window(bufnr, modifier, size)
   M.resize_windows_on_stack()
 end
 
@@ -45,10 +45,12 @@ end
 ---@param modifier string
 ---@param size? size|fun():size
 function M.create_window(bufnr, modifier, size)
-  if size == nil
-    then size = ""
+  if size == "default"
+  then
+    size = get_size()
   elseif type(size) == "function"
-    then size = size()
+  then
+    size = size()
   end
 
   local cmd = "split"

--- a/lua/overseer/component/officer/open_on_start.lua
+++ b/lua/overseer/component/officer/open_on_start.lua
@@ -6,7 +6,7 @@ return {
     modifier = {
       desc = "Direction modifier for window created",
       type = "string",
-      default = "",
+      default = "botright vertical",
     },
     close_on_exit = {
       desc = "Close the window on exit",
@@ -17,6 +17,7 @@ return {
     size = {
       desc = "Size of the window to create",
       type = "opaque",
+      default = "default",
     },
   },
   constructor = function(params)
@@ -24,7 +25,7 @@ return {
       bufnr = nil,
       on_start = function(self, task)
         self.bufnr = task:get_bufnr()
-        oui.add_window_to_stack(self.bufnr)
+        oui.add_window_to_stack(self.bufnr, params.modifier, params.size)
         vim.api.nvim_win_set_buf(0, self.bufnr)
 
         -- vim.api.nvim_feedkeys("G", "n", false)


### PR DESCRIPTION
I have been trying to use the `officer.open_on_start` component, and realized that it doesn't actually use the `modifier` and `size` parameters. This PR fixes that.