### PR TITLE
Add on_complete_trouble_quickfix component

### DIFF
--- a/lua/officer/ui.lua
+++ b/lua/officer/ui.lua
@@ -15,14 +15,14 @@ function M.resize_windows_on_stack()
 end
 
 ---@param bufnr number
-function M.add_window_to_stack(bufnr)
+function M.add_window_to_stack(bufnr, modifier, size)
   local last_window = stack[#stack]
   if not last_window or not vim.api.nvim_win_is_valid(last_window.winid) then
-    M.create_window(bufnr, "botright vertical", get_size())
+    M.create_window(bufnr, modifier, size)
     return
   end
   vim.api.nvim_set_current_win(last_window.winid)
-  M.create_window(bufnr, "belowright")
+  M.create_window(bufnr, modifier, size)
   M.resize_windows_on_stack()
 end
 
@@ -45,10 +45,12 @@ end
 ---@param modifier string
 ---@param size? size|fun():size
 function M.create_window(bufnr, modifier, size)
-  if size == nil
-    then size = ""
+  if size == "default"
+  then
+    size = get_size()
   elseif type(size) == "function"
-    then size = size()
+  then
+    size = size()
   end
 
   local cmd = "split"

--- a/lua/overseer/component/officer/on_complete_trouble_quickfix.lua
+++ b/lua/overseer/component/officer/on_complete_trouble_quickfix.lua
@@ -1,0 +1,37 @@
+return {
+  desc = "Open Trouble quickfix when the errorformat finds a match",
+  params = {
+    close_on_exit = {
+      desc = "Close Trouble when task exits without errors",
+      type = "boolean",
+      default = false,
+    },
+  },
+  constructor = function(params)
+    return {
+      on_complete = function(self, _task, status, _result)
+        local builtin_qf_list = vim.fn.getqflist()
+
+        if status == 'SUCCESS' or #builtin_qf_list == 0 then
+          if params.close_on_exit then
+            require("trouble").close()
+          end
+          return
+        end
+
+        local trouble_qf_list = require("trouble.sources.qf").get_list()
+        if #trouble_qf_list == 0 then
+          -- This means the quickfix list contains invalid entries
+          -- Open the builtin quickfix list in that case.
+          if params.close_on_exit then
+            require("trouble").close()
+          end
+          vim.cmd("botright copen")
+          return
+        end
+
+        require("trouble").open("quickfix")
+      end,
+    }
+  end,
+}

--- a/lua/overseer/component/officer/open_on_start.lua
+++ b/lua/overseer/component/officer/open_on_start.lua
@@ -6,7 +6,7 @@ return {
     modifier = {
       desc = "Direction modifier for window created",
       type = "string",
-      default = "",
+      default = "botright vertical",
     },
     close_on_exit = {
       desc = "Close the window on exit",
@@ -17,6 +17,7 @@ return {
     size = {
       desc = "Size of the window to create",
       type = "opaque",
+      default = "default",
     },
   },
   constructor = function(params)
@@ -24,7 +25,7 @@ return {
       bufnr = nil,
       on_start = function(self, task)
         self.bufnr = task:get_bufnr()
-        oui.add_window_to_stack(self.bufnr)
+        oui.add_window_to_stack(self.bufnr, params.modifier, params.size)
         vim.api.nvim_win_set_buf(0, self.bufnr)
 
         -- vim.api.nvim_feedkeys("G", "n", false)


### PR DESCRIPTION
This PR adds a on_complete_trouble_quickfix which opens the Trouble quickfix UI once a task completes. This must be used in combination with the `on_output_quickfix` component to fill quickfixes from the task output.